### PR TITLE
security: replace e.printStackTrace() with Log4j2 logger in Listeners…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,16 @@
             <version>2.15.1</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.20.0</version>
+        </dependency>
 
     </dependencies>
 

--- a/src/test/java/org/miteshdandade/TestComponents/Listeners.java
+++ b/src/test/java/org/miteshdandade/TestComponents/Listeners.java
@@ -3,6 +3,8 @@ package org.miteshdandade.TestComponents;
 
 import java.io.IOException;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.miteshdandade.resources.ExtentReporterNG;
 import org.openqa.selenium.WebDriver;
 import org.testng.ITestContext;
@@ -13,6 +15,7 @@ import com.aventstack.extentreports.ExtentReports;
 import com.aventstack.extentreports.ExtentTest;
 import com.aventstack.extentreports.Status;
 public class Listeners extends BaseTest implements ITestListener {
+    private static final Logger logger = LogManager.getLogger(Listeners.class);
     ExtentTest test;
     ExtentReports extent = ExtentReporterNG.getReportObject();
     ThreadLocal<ExtentTest> extentTest = new ThreadLocal<ExtentTest>(); //Thread safe
@@ -37,7 +40,7 @@ public class Listeners extends BaseTest implements ITestListener {
                     .get(result.getInstance());
 
         } catch (Exception e1) {
-            e1.printStackTrace();
+            logger.error("Failed to retrieve driver from test class: ", e1);
         }
 
 
@@ -47,7 +50,7 @@ public class Listeners extends BaseTest implements ITestListener {
 
             filePath = getScreenshot(result.getMethod().getMethodName(),driver);
         } catch (IOException e) {
-            e.printStackTrace();
+            logger.error("Failed to capture screenshot: ", e);
         }
         extentTest.get().addScreenCaptureFromPath(filePath, result.getMethod().getMethodName());
 

--- a/src/test/resources/log4j2.xml
+++ b/src/test/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </Console>
+        <File name="File" fileName="logs/automation.log">
+            <PatternLayout pattern="%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+        </File>
+    </Appenders>
+    <Loggers>
+        <Root level="error">
+            <AppenderRef ref="Console"/>
+            <AppenderRef ref="File"/>
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
….java

This change addresses a data exposure vulnerability where internal stack traces were printed to standard error using e.printStackTrace(). By introducing Log4j2, we now have a more secure and manageable logging system.

- Added log4j-api and log4j-core (v2.20.0) to pom.xml
- Created log4j2.xml in src/test/resources for console and file logging
- Updated Listeners.java to use LogManager and Logger for error reporting