### PR TITLE
🧹 Remove unused import in ProductCatalogue.java

### DIFF
--- a/src/main/java/org/miteshdandade/pageobjects/ProductCatalogue.java
+++ b/src/main/java/org/miteshdandade/pageobjects/ProductCatalogue.java
@@ -7,7 +7,6 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 import org.openqa.selenium.support.PageFactory;
-import org.openqa.selenium.support.ui.ExpectedConditions;
 
 import org.miteshdandade.AbstractComponents.AbstractComponent;
 


### PR DESCRIPTION
🎯 **What:** The import statement `org.openqa.selenium.support.ui.ExpectedConditions` was removed from `src/main/java/org/miteshdandade/pageobjects/ProductCatalogue.java`. 💡 **Why:** The import was not referenced anywhere in the class. Removing it improves code maintainability and readability by reducing clutter. ✅ **Verification:** Verified by code inspection and exhaustive searching to ensure no references were missed. Manual review confirmed this is a safe, no-op refactoring. ✨ **Result:** A cleaner and more maintainable `ProductCatalogue.java` file.